### PR TITLE
NodeJS version, lambda and step function updates

### DIFF
--- a/server/serverless-account-create.yml
+++ b/server/serverless-account-create.yml
@@ -3,12 +3,14 @@ functions:
     handler: src/handler/account-flow-handler.createAccount
   stepCreateAdGroup:
     handler: src/handler/account-flow-handler.createAdGroup
+    timeout: 30
   stepValidateAdGroup:
     handler: src/handler/account-flow-handler.validateAdGroup
   stepCreateAwsAccount:
     handler: src/handler/account-flow-handler.createAwsAccount
   stepValidateAwsAccount:
     handler: src/handler/account-flow-handler.validateAwsAccount
+    timeout: 30
   stepCreateBudget:
     handler: src/handler/account-flow-handler.createBudget
   stepValidateSsoGroup:
@@ -50,7 +52,7 @@ stepFunctions:
               - ErrorEquals:
                   - NOT_READY
                 IntervalSeconds: 10
-                MaxAttempts: 10
+                MaxAttempts: 20
                 BackoffRate: 1
             Next: Create account in AWS
           Create account in AWS:
@@ -74,7 +76,7 @@ stepFunctions:
               - ErrorEquals:
                   - NOT_READY
                 IntervalSeconds: 180
-                MaxAttempts: 20
+                MaxAttempts: 30
                 BackoffRate: 1
             Next: Create AWS Budget
           Create AWS Budget:

--- a/server/serverless.yml
+++ b/server/serverless.yml
@@ -26,7 +26,7 @@ provider:
         - sso-directory:*
         - sns:*
       Resource: "*"
-  runtime: nodejs10.x
+  runtime: nodejs12.x
   stage: ${opt:stage, "test"}
   region: ${opt:region, "eu-west-1"}
   environment:


### PR DESCRIPTION
* bump nodejs version to v12
* increase timeouts for critical lambdas (createAdGroup, validateAwsAccount)
* increase states (SF) max attempts for longer processes (Validate AD group created, Validate AWS account created)

These changes should solved issues with missing aws accountIds and non-existing budgets.
Note: if we faced the same issues after the testing phase, additional logic should be added within lambdas (have it in progress phase at this point of time)